### PR TITLE
Fix data binding infinite loop issue

### DIFF
--- a/app/src/main/java/com/junting/drug_android_frontend/DrugRecordActivity.kt
+++ b/app/src/main/java/com/junting/drug_android_frontend/DrugRecordActivity.kt
@@ -163,19 +163,12 @@ class DrugRecordActivity : AppCompatActivity() {
         viewModel.fetchRecord(drugRecordId!!)
         viewModel.record.observe(this, Observer {
             Log.d("Observe DrugRecord", "record: ${it.toString()}")
-
             var timeSlots = it.timeSlots.toMutableList()
-            viewModel.setTimeSlots(timeSlots)
             initTimeSection(timeSlots)
-
             initExpandableListInteraction(it.interactingDrugs!!)
-            viewModel.setInteractingDrugs(it.interactingDrugs!!)
-
             for (i in it.timings) {
                 checkBoxes[i].isChecked = true
             }
-            viewModel.setTimings(it.timings)
-
             binding.progressBar.visibility = GONE
         })
     }


### PR DESCRIPTION
The root cause of it is setting viewModel value inside observe callback. Calling viewModel setter method would trigger observe again, so it'll become infinite loop. But in this case, we don't need to call setter method there because the data is already updated.